### PR TITLE
ML - Fix Empty Cart

### DIFF
--- a/src/cart/index.html
+++ b/src/cart/index.html
@@ -91,9 +91,7 @@
           </li> -->
         </ul>
       </section>
-      <section class="checkout-area">
-        
-      </section>
+      <section class="checkout-area"></section>
     </main>
 
     <footer>&copy;NOT a real business</footer>

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -1,7 +1,7 @@
 import { getLocalStorage } from "./utils.mjs";
 
 function renderCartContents() {
-  const cartItems = getLocalStorage("so-cart");
+  const cartItems = getLocalStorage("so-cart") || []; // Need to return an empty array if LocalStorage is empty.
   const htmlItems = cartItems.map((item) => cartItemTemplate(item));
   document.querySelector(".product-list").innerHTML = htmlItems.join("");
   

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -5,7 +5,7 @@ function renderCartContents() {
   const htmlItems = cartItems.map((item) => cartItemTemplate(item));
   document.querySelector(".product-list").innerHTML = htmlItems.join("");
   
-  /* The `if` statement is checking if the `cartItems` variable is not null. If it is not null, it means that there are items in the cart. */
+  // cartItems will now never be NULL. More appropriate to check for empty array.
   if (cartItems.length > 0) {
     //console.log("The cart has something"); 
     let totalItems = cartItems.map(function(item){

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -1,12 +1,12 @@
 import { getLocalStorage } from "./utils.mjs";
 
 function renderCartContents() {
-  const cartItems = getLocalStorage("so-cart") || []; // Need to return an empty array if LocalStorage is empty.
+  const cartItems = getLocalStorage("so-cart") || []; // Need to assign an empty array if LocalStorage is null (empty).
   const htmlItems = cartItems.map((item) => cartItemTemplate(item));
   document.querySelector(".product-list").innerHTML = htmlItems.join("");
   
   /* The `if` statement is checking if the `cartItems` variable is not null. If it is not null, it means that there are items in the cart. */
-  if (cartItems != null) {
+  if (cartItems.length > 0) {
     //console.log("The cart has something"); 
     let totalItems = cartItems.map(function(item){
       let total = [];

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -4,31 +4,34 @@ function renderCartContents() {
   const cartItems = getLocalStorage("so-cart") || []; // Need to assign an empty array if LocalStorage is null (empty).
   const htmlItems = cartItems.map((item) => cartItemTemplate(item));
   document.querySelector(".product-list").innerHTML = htmlItems.join("");
-  
+
   // cartItems will now never be NULL. More appropriate to check for empty array.
   if (cartItems.length > 0) {
-    //console.log("The cart has something"); 
-    let totalItems = cartItems.map(function(item){
+    //console.log("The cart has something");
+    let totalItems = cartItems.map(function (item) {
       let total = [];
-      total.push(item.FinalPrice); 
-      return total; 
-    }); 
-    document.querySelector(".checkout-area").innerHTML = checkoutTemplate(totalItems);
+      total.push(item.FinalPrice);
+      return total;
+    });
+    document.querySelector(".checkout-area").innerHTML =
+      checkoutTemplate(totalItems);
   }
 }
 
-function checkoutTemplate(items){
-  let sumTotal = 0; 
-  items.forEach(value => {sumTotal += parseFloat(value)}); 
+function checkoutTemplate(items) {
+  let sumTotal = 0;
+  items.forEach((value) => {
+    sumTotal += parseFloat(value);
+  });
   /* console.log("Checking")
   console.log(sumTotal); */
-  
+
   const totalPrice = `<div class="cart-footer-hide">
   <p class="cart-total">Total: $${sumTotal}</p>
   <button id="checkoutBtn">Checkout</button>
-</div>`
-return totalPrice; 
-}; 
+</div>`;
+  return totalPrice;
+}
 
 function cartItemTemplate(item) {
   const newItem = `<li class="cart-card divider">


### PR DESCRIPTION
Fixed a console error that was popping up in the shopping cart when it was empty. Changed the initialization of `cartItems` to be assigned an empty array in the event that LocalStorage is NULL. This subsequently changes Felix's conditional: Instead of checking against NULL, it checks the size of the array displays items only if `length > 0`. 